### PR TITLE
fixing transaction-alert/src/main/resources/scripts/create-topics.sh …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /transaction-alert/build/classes/java/main/
 /transaction-alert/build/resources/
 /transaction-alert/build/tmp/
+/.idea/

--- a/semi-manual-testing/transactions-alert/data/transactions.data
+++ b/semi-manual-testing/transactions-alert/data/transactions.data
@@ -2,3 +2,4 @@
 54321:{"id":54321,"amount":353.53,"outgoing": true, "type": "withdrawal", "country": {"string": "Poland"}, "userId": {"long": 123}}
 11111:{"id":11111,"amount":947.32,"outgoing": true, "type": "withdrawal", "country": {"string": "France"}, "userId": {"long": 321}}
 22222:{"id":22222,"amount":635.73,"outgoing": true, "type": "withdrawal", "country": {"string": "France"}, "userId": {"long": 321}}
+33333:{"id":33333,"amount":1505.73,"outgoing": true, "type": "withdrawal", "country": {"string": "Germany"}, "userId": {"long": 321}}

--- a/semi-manual-testing/transactions-alert/scripts/alerts.sh
+++ b/semi-manual-testing/transactions-alert/scripts/alerts.sh
@@ -1,6 +1,5 @@
 kafka-avro-console-consumer --bootstrap-server broker:29092 \
+--property parse.key=true \
 --topic alerts \
---property key.schema='{"type": "long"}' \
---property print.key=true \
 --from-beginning \
---property value.schema='{"type": "record", "name": "Alert", "namespace": "prv.saevel.kafka.academy.testing.transaction.alert", "fields": [{"name": "userId", "type": "long"}, {"name": "transactionId", "type": "long"}, {"name": "code", "type": "long"}, {"name": "message", "type": "string"}]}'
+--property schema.registry.url=http://localhost:8081

--- a/semi-manual-testing/transactions-alert/scripts/transactions.sh
+++ b/semi-manual-testing/transactions-alert/scripts/transactions.sh
@@ -2,5 +2,5 @@ kafka-avro-console-producer --topic transactions \
 --broker-list broker:29092 \
 --property key.schema='{"type": "long"}' \
 --property parse.key=true \
---property key.separator=":"\
+--property key.separator=":" \
 --property value.schema='{"type": "record","name": "Transaction", "namespace": "prv.saevel.kafka.academy.testing.transaction.alert", "fields": [{"name": "id", "type": "long"}, {"name": "amount", "type": "double", "default": 0}, {"name": "outgoing", "type": "boolean"}, {"name": "type", "type": "string"}, {"name": "country", "type": ["null", "string"], "default": null}, {"name": "userId", "type": ["null", "long"], "default": null}]}'

--- a/transaction-alert/src/main/java/prv/saevel/kafka/academy/TransactionsAlertApplication.java
+++ b/transaction-alert/src/main/java/prv/saevel/kafka/academy/TransactionsAlertApplication.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 
 public class TransactionsAlertApplication {
 
-    public static final Duration ANALYSIS_WINDOW = Duration.ofMinutes(15);
+    public static final Duration ANALYSIS_WINDOW = Duration.ofMinutes(2);
 
     public static final String USERS_TOPIC = "users";
 

--- a/transaction-alert/src/main/resources/scripts/create-topics.sh
+++ b/transaction-alert/src/main/resources/scripts/create-topics.sh
@@ -1,11 +1,11 @@
-kafka-topics --create --topic splitter-input --partitions 2 --replication-factor 1
+kafka-topics --create --topic splitter-input --bootstrap-server localhost:29092 --partitions 2 --replication-factor 1
 
-kafka-topics --create --topic splitter-output --partitions 2 --replication-factor 1
+kafka-topics --create --topic splitter-output --bootstrap-server localhost:29092 --partitions 2 --replication-factor 1
 
-kafka-topics --create --topic users --partitions 2 --replication-factor 1
+kafka-topics --create --topic users --bootstrap-server localhost:29092 --partitions 2 --replication-factor 1
 
-kafka-topics --create --topic users_rekeyed --partitions 2 --replication-factor 1
+kafka-topics --create --topic users_rekeyed --bootstrap-server localhost:29092 --partitions 2 --replication-factor 1
 
-kafka-topics --create --topic transactions --partitions 2 --replication-factor 1
+kafka-topics --create --topic transactions --bootstrap-server localhost:29092 --partitions 2 --replication-factor 1
 
-kafka-topics --create --topic alerts --partitions 2 --replication-factor 1
+kafka-topics --create --topic alerts --bootstrap-server localhost:29092 --partitions 2 --replication-factor 1


### PR DESCRIPTION
…to work with new repo cp-all-in-one https://github.com/confluentinc/cp-all-in-one

Before change there were following error:
```
[appuser@broker ~]$ kafka-topics --create --topic alerts --partitions 2 --replication-factor 1
Exception in thread "main" java.lang.IllegalArgumentException: Only one of --bootstrap-server or --zookeeper must be specified
	at kafka.admin.TopicCommand$TopicCommandOptions.checkArgs(TopicCommand.scala:862)
	at kafka.admin.TopicCommand$.main(TopicCommand.scala:59)
	at kafka.admin.TopicCommand.main(TopicCommand.scala)
```